### PR TITLE
add ARM Linux GitHub Actions runner

### DIFF
--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [ 21 ]
-        os: [ 'ubuntu-22.04' ]
+        os: [ 'ubuntu-22.04', 'ubuntu-22.04-arm' ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/


